### PR TITLE
Add a basic Visual Studio Code extension example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Fable + React Native](https://github.com/fable-compiler/fable-react_native-demo) - Full React Native app using Fable.
 * [Fable + Fuse](https://github.com/alfonsogarciacaro/MyFuseApp) - Simple F# cross-platform mobile app based on [Fuse Tools](https://www.fusetools.com/) quickstart tutorial.
 * [fable-electron](https://github.com/fable-compiler/fable-electron) - Learn how to write a cross-platorm desktop app in F# with Fable and Github Electron.
+* [fable vscode](https://github.com/acormier/vscode-extension-fable-simple) - Basic Visual Studio Code 'Hello Word!' extension.
 
 **[:arrow_up: back to top](#table-of-contents)**
 


### PR DESCRIPTION
@alfonsogarciacaro [suggested](https://github.com/fable-compiler/Fable/issues/867#issuecomment-300626250) that I add a link to my basic Visual Studio Code extension [sample](https://github.com/acormier/vscode-extension-fable-simple).

Cheers,
Alain