### PR TITLE
Fulma minimal template - URL Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Elmish templates](https://github.com/fable-elmish/templates) - Templates to kick start a new Elmish application.
   Install them like `dotnet new -i "Fable.Template.Elmish.React::*"` and create a project with `dotnet new fable-elmish-react -n myproject`
 * [SAFE template](https://github.com/SAFE-Stack/SAFE-template) - Dotnet CLI template to bootstrap [SAFE](https://safe-stack.github.io/) projects, including [Suave.IO](https://suave.io/) on server side
-* [Fulma minimal template](https://mangelmaxime.github.io/Fulma/#template) - The quickest way to get started an Elmish + Fulma application from scratch
+* [Fulma minimal template](https://fulma.github.io/Fulma/) - The quickest way to get started an Elmish + Fulma application from scratch
 * [Fable.Library.Template](https://github.com/TheAngryByrd/Fable.Library.Template) - F# Template for create and publishing Fable Libraries
 
 **[:arrow_up: back to top](#table-of-contents)**


### PR DESCRIPTION
Updated the url from https://mangelmaxime.github.io/Fulma/#template to https://fulma.github.io/Fulma/