### PR TITLE
Removing no-longer-relevant link to device-scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [tabula-rasa](https://github.com/Zaid-Ajaj/tabula-rasa) - Minimalistic real-worldish blogging platform, written entirely in F#, made as a learning reference for building large Elmish apps
 * [SAFE TodoList](https://github.com/Zaid-Ajaj/SAFE-TodoList) - The simplest Todo app: a client-server application written entirely in F# using Elmish on the client, Suave on the server and Fable.Remoting for type-safe communication between the two.
 * [Fable-Elmish-Electron-Material-UI demo](https://github.com/cmeeren/fable-elmish-electron-material-ui-demo) - Complete boilerplate for Electron apps using Fable 2 and Elmish with hot module reloading, time-travel debugging, etc. Also demoes how to implement some non-trivial UX patterns in Elmish, as well as how to use Material-UI with JSS (styles as code).
-* [device-scanner](https://github.com/intel-hpdd/device-scanner) - A Production Fable -> Node.js daemon for monitoring Linux storage devices. Has full testing + code coverage.
 * [Volca FM editor](https://magicmonty.github.io/volca-fm-editor) - A Patch editor for the Korg Volca FM made with Fable-Elmish-React which uses Web MIDI
 * [fable-webmidi-sample](https://github.com/magicmonty/fable-webmidi-sample) - A simple sample for making a Web MIDI application with fable
 * [fable-uploadcare](https://whitetigle.github.io/fable-uploadcare/) - A simple React sample to use [UploadCare](https://uploadcare.com) widget


### PR DESCRIPTION
Looks like in [this commit](https://github.com/whamcloud/device-scanner/commit/b4ba770e8dc1b3827c85322117af9d9dbf31911a), the whole repo was changed to a Rust solution.