### PR TITLE
Add link to office-fable to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Inspired by the [awesome](#more-awesome) list thing. Feel free to <a href="https
 * [Fable.AntD](https://github.com/uxsoft/Fable.AntD) - Ant Design bindings for Fable
 * [Fable.MomentJs](https://github.com/uxsoft/Fable.MomentJs) - packaged MomentJs bindings by [Prolucid](https://github.com/Prolucid/fable-import-momentjs)
 * [Fss](https://github.com/Bjorn-Strom/FSS) - Type-safe CSS styling library.
+* [office-fable](https://github.com/Freymaurer/office-fable) - Fable bindings for office-js.
 
 **[:arrow_up: back to top](#table-of-contents)**
 


### PR DESCRIPTION
Add link to office-fable, a fable compatible library for office-js bindings. Let me know if this fits or not 👍 